### PR TITLE
Updated cargo config: using ndk19's precompiled toolchain

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,15 @@
-[target.aarch64-linux-android]
-linker = "/home/pleb/android-ndk-r18/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-gcc"
-rustflags = ["-Clink-args=--sysroot /home/pleb/android-ndk-r18/platforms/android-28/arch-arm64 -fuse-ld=lld -L/home/pleb/android-ndk-r18/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/lib/gcc/aarch64-linux-android/4.9.x"]
-
 [target.arm-linux-androideabi]
-linker = "/home/pleb/android-ndk-r18/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-gcc"
-rustflags = ["-Clink-args=--sysroot /home/pleb/android-ndk-r18/platforms/android-18/arch-arm -fuse-ld=lld -L/home/pleb/android-ndk-r18/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9.x"]
+ar = "/home/pleb/android-ndk-r19/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ar"
+linker = "/home/pleb/android-ndk-r19/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi24-clang"
 
+[target.aarch64-linux-android]
+ar = "/home/pleb/android-ndk-r19/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
+linker = "/home/pleb/android-ndk-r19/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
+
+[target.i686-linux-android]
+ar = "/home/pleb/android-ndk-r19/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android-ar"
+linker = "/home/pleb/android-ndk-r19/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android24-clang"
+
+[target.x86_64-linux-android]
+ar = "/home/pleb/android-ndk-r19/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-ar"
+linker = "/home/pleb/android-ndk-r19/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android24-clang"


### PR DESCRIPTION
Now supporting x86, x64, arm and aarch64.

Tested on rooted x86 and x64 Pixel 2 SDK 25 emulators and a rooted arm Pixel 1 device. SELinux needs to be turned off for directory listing to work. 