### PR TITLE
Added makefiles for x86 and x64

### DIFF
--- a/test_x64.mk
+++ b/test_x64.mk
@@ -1,0 +1,7 @@
+all:
+	cargo build --target x86_64-linux-android --release
+	adb reverse tcp:13370 tcp:13370
+	adb push target/x86_64-linux-android/release/slime_tree /data/local/tmp/slime_tree
+	adb shell chmod 755 /data/local/tmp/slime_tree
+	adb shell /data/local/tmp/slime_tree
+

--- a/test_x86.mk
+++ b/test_x86.mk
@@ -1,0 +1,7 @@
+all:
+	cargo build --release --target=i686-linux-android
+	adb reverse tcp:13370 tcp:13370
+	adb push target/i686-linux-android/release/slime_tree /data/local/tmp/slime_tree
+	adb shell chmod 755 /data/local/tmp/slime_tree
+	adb shell /data/local/tmp/slime_tree
+


### PR DESCRIPTION
Forgot this in yesterday's PR #1: makefiles for x86 and x64 that build, deploy and run the fuzzer.
As for PR #1: tested on rooted x86 and x64 Pixel 2 XL emulators running SDK 25